### PR TITLE
Add HID transport (macOS IOKit + Linux hidraw) and C FFI layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+zig-out/

--- a/include/ctap2.h
+++ b/include/ctap2.h
@@ -1,24 +1,76 @@
-// C header for libctap2 — portable CTAP2/FIDO2 over USB HID.
-// Auto-consumed by Swift via bridging header / module map.
+// libctap2 — Portable CTAP2/FIDO2 over USB HID.
+// C API for Swift/ObjC interop via bridging header.
+//
+// All functions are blocking (with timeouts) and thread-safe.
+// Result data is CBOR-encoded CTAP2 responses written to caller buffers.
 
 #ifndef CTAP2_H
 #define CTAP2_H
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// TODO: C function declarations will be added as ffi.zig is implemented.
-
 // Status codes
-#define CTAP2_OK 0
-#define CTAP2_ERR_NO_DEVICE -1
-#define CTAP2_ERR_TIMEOUT -2
-#define CTAP2_ERR_PROTOCOL -3
+#define CTAP2_OK                    0
+#define CTAP2_ERR_NO_DEVICE        -1
+#define CTAP2_ERR_TIMEOUT          -2
+#define CTAP2_ERR_PROTOCOL         -3
 #define CTAP2_ERR_BUFFER_TOO_SMALL -4
+#define CTAP2_ERR_OPEN_FAILED      -5
+#define CTAP2_ERR_WRITE_FAILED     -6
+#define CTAP2_ERR_READ_FAILED      -7
+#define CTAP2_ERR_CBOR             -8
+#define CTAP2_ERR_DEVICE           -9
+
+// Get the number of connected FIDO2 devices.
+int ctap2_device_count(void);
+
+// Perform authenticatorMakeCredential.
+// client_data_hash must be 32 bytes (SHA-256 of clientDataJSON).
+// Returns bytes written to result_buf, or negative error code.
+// result_buf contains the raw CTAP2 response (status byte + CBOR).
+int ctap2_make_credential(
+    const uint8_t *client_data_hash,     // 32 bytes
+    const char *rp_id,                    // null-terminated
+    const char *rp_name,                  // null-terminated
+    const uint8_t *user_id,
+    size_t user_id_len,
+    const char *user_name,               // null-terminated
+    const char *user_display_name,       // null-terminated
+    const int32_t *alg_ids,              // COSE algorithm IDs
+    size_t alg_count,
+    bool resident_key,
+    uint8_t *result_buf,
+    size_t result_buf_len
+);
+
+// Perform authenticatorGetAssertion.
+// client_data_hash must be 32 bytes.
+// allow_list_ids is an array of pointers to credential IDs.
+// allow_list_id_lens is an array of lengths for each credential ID.
+// Returns bytes written to result_buf, or negative error code.
+int ctap2_get_assertion(
+    const uint8_t *client_data_hash,     // 32 bytes
+    const char *rp_id,                    // null-terminated
+    const uint8_t *const *allow_list_ids,
+    const size_t *allow_list_id_lens,
+    size_t allow_list_count,
+    uint8_t *result_buf,
+    size_t result_buf_len
+);
+
+// Perform authenticatorGetInfo.
+// Returns bytes written to result_buf, or negative error code.
+// result_buf contains the raw CTAP2 response (status byte + CBOR).
+int ctap2_get_info(
+    uint8_t *result_buf,
+    size_t result_buf_len
+);
 
 #ifdef __cplusplus
 }

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -1,6 +1,247 @@
-/// C FFI exports for Swift/ObjC interop.
-/// TODO: implement after core protocol is tested
+/// C FFI exports for libctap2.
+///
+/// These functions are called from Swift via the bridging header.
+/// All functions are blocking (with timeouts) and thread-safe.
+/// Result data is written to caller-provided buffers.
+
 const std = @import("std");
 const cbor = @import("cbor.zig");
 const ctaphid = @import("ctaphid.zig");
 const ctap2 = @import("ctap2.zig");
+const hid = @import("hid.zig");
+
+const CTAP2_OK: c_int = 0;
+const CTAP2_ERR_NO_DEVICE: c_int = -1;
+const CTAP2_ERR_TIMEOUT: c_int = -2;
+const CTAP2_ERR_PROTOCOL: c_int = -3;
+const CTAP2_ERR_BUFFER_TOO_SMALL: c_int = -4;
+const CTAP2_ERR_OPEN_FAILED: c_int = -5;
+const CTAP2_ERR_WRITE_FAILED: c_int = -6;
+const CTAP2_ERR_READ_FAILED: c_int = -7;
+const CTAP2_ERR_CBOR: c_int = -8;
+const CTAP2_ERR_DEVICE: c_int = -9;
+
+/// Perform a full CTAPHID transaction: send command, receive response.
+/// Handles CTAPHID_INIT (channel negotiation) + CTAPHID_CBOR (command).
+fn ctaphidTransaction(
+    dev: *hid.Device,
+    cmd_payload: []const u8,
+    result_buf: []u8,
+) !usize {
+    // Step 1: CTAPHID_INIT to get a channel ID
+    var nonce: [8]u8 = undefined;
+    std.crypto.random.bytes(&nonce);
+
+    var init_pkt = ctaphid.buildInitPacket(ctaphid.CID_BROADCAST, .init, 8, &nonce);
+    try dev.write(&init_pkt);
+
+    const init_resp_pkt = try dev.read(5000); // 5 second timeout
+    const init_header = try ctaphid.parseInitPacket(&init_resp_pkt);
+    if (init_header.cmd != .init) return error.Protocol;
+
+    // Parse CTAPHID_INIT response to get assigned CID
+    const init_data = init_resp_pkt[7..][0..@min(@as(usize, init_header.payload_len), ctaphid.INIT_DATA_SIZE)];
+    const init_resp = try ctaphid.parseInitResponse(init_data);
+    const cid = init_resp.cid;
+
+    // Step 2: Send CTAP2 CBOR command
+    var packets: [128]ctaphid.Packet = undefined;
+    const pkt_count = try ctaphid.fragmentMessage(cid, .cbor, cmd_payload, &packets);
+
+    for (packets[0..pkt_count]) |*pkt| {
+        try dev.write(pkt);
+    }
+
+    // Step 3: Read response (handle keepalive)
+    var resp_buf: [4096]u8 = undefined;
+    var first_pkt = try dev.read(30000); // 30 second timeout for user interaction
+
+    // Handle keepalive packets (device waiting for user touch)
+    while (true) {
+        const hdr = ctaphid.parseInitPacket(&first_pkt) catch break;
+        if (hdr.cmd == .keepalive) {
+            // Keep reading — device is waiting for user touch
+            first_pkt = try dev.read(30000);
+            continue;
+        }
+        break;
+    }
+
+    // Reassemble response
+    var offset: usize = 0;
+    const resp_header = try ctaphid.parseInitPacket(&first_pkt);
+    const total_len: usize = @intCast(resp_header.payload_len);
+
+    if (total_len > resp_buf.len) return error.BufferTooSmall;
+
+    // Copy init packet data
+    const init_copy = @min(total_len, ctaphid.INIT_DATA_SIZE);
+    @memcpy(resp_buf[0..init_copy], first_pkt[7..][0..init_copy]);
+    offset = init_copy;
+
+    // Read continuation packets
+    while (offset < total_len) {
+        const cont_pkt = try dev.read(5000);
+        // Skip keepalive
+        if (cont_pkt[4] & 0x80 != 0) {
+            const cont_hdr = ctaphid.parseInitPacket(&cont_pkt) catch continue;
+            if (cont_hdr.cmd == .keepalive) continue;
+        }
+        const cont_copy = @min(total_len - offset, ctaphid.CONT_DATA_SIZE);
+        @memcpy(resp_buf[offset..][0..cont_copy], cont_pkt[5..][0..cont_copy]);
+        offset += cont_copy;
+    }
+
+    // Copy to result buffer
+    if (total_len > result_buf.len) return error.BufferTooSmall;
+    @memcpy(result_buf[0..total_len], resp_buf[0..total_len]);
+    return total_len;
+}
+
+// ─── Exported C Functions ───────────────────────────────────
+
+/// Enumerate FIDO2 devices. Returns device count.
+export fn ctap2_device_count() callconv(.c) c_int {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const devices = hid.enumerate(allocator) catch return 0;
+    const count: c_int = @intCast(devices.len);
+    for (devices) |*dev| {
+        var d = dev.*;
+        d.close();
+    }
+    allocator.free(devices);
+    return count;
+}
+
+/// Perform authenticatorMakeCredential via direct USB HID.
+/// Returns bytes written to result_buf, or negative error code.
+export fn ctap2_make_credential(
+    client_data_hash: [*]const u8, // 32 bytes
+    rp_id: [*:0]const u8,
+    rp_name: [*:0]const u8,
+    user_id: [*]const u8,
+    user_id_len: usize,
+    user_name: [*:0]const u8,
+    user_display_name: [*:0]const u8,
+    alg_ids: [*]const i32,
+    alg_count: usize,
+    resident_key: bool,
+    result_buf: [*]u8,
+    result_buf_len: usize,
+) callconv(.c) c_int {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Open first FIDO2 device
+    var dev = hid.openFirst(allocator) catch return CTAP2_ERR_NO_DEVICE;
+    defer dev.close();
+
+    // Encode CTAP2 makeCredential command
+    var cmd_buf: [2048]u8 = undefined;
+    const cmd = ctap2.encodeMakeCredential(
+        &cmd_buf,
+        client_data_hash[0..32],
+        std.mem.span(rp_id),
+        std.mem.span(rp_name),
+        user_id[0..user_id_len],
+        std.mem.span(user_name),
+        std.mem.span(user_display_name),
+        @ptrCast(alg_ids[0..alg_count]),
+        resident_key,
+    ) catch return CTAP2_ERR_CBOR;
+
+    // Send and receive
+    const result_len = ctaphidTransaction(&dev, cmd, result_buf[0..result_buf_len]) catch |err| {
+        return switch (err) {
+            error.NoDeviceFound => CTAP2_ERR_NO_DEVICE,
+            error.Timeout => CTAP2_ERR_TIMEOUT,
+            error.WriteFailed => CTAP2_ERR_WRITE_FAILED,
+            error.ReadFailed => CTAP2_ERR_READ_FAILED,
+            error.BufferTooSmall => CTAP2_ERR_BUFFER_TOO_SMALL,
+            else => CTAP2_ERR_PROTOCOL,
+        };
+    };
+
+    return @intCast(result_len);
+}
+
+/// Perform authenticatorGetAssertion via direct USB HID.
+/// Returns bytes written to result_buf, or negative error code.
+export fn ctap2_get_assertion(
+    client_data_hash: [*]const u8, // 32 bytes
+    rp_id: [*:0]const u8,
+    allow_list_ids: [*]const [*]const u8,
+    allow_list_id_lens: [*]const usize,
+    allow_list_count: usize,
+    result_buf: [*]u8,
+    result_buf_len: usize,
+) callconv(.c) c_int {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Open first FIDO2 device
+    var dev = hid.openFirst(allocator) catch return CTAP2_ERR_NO_DEVICE;
+    defer dev.close();
+
+    // Build allow list slices
+    var ids_buf: [64][]const u8 = undefined;
+    const count = @min(allow_list_count, 64);
+    for (0..count) |i| {
+        ids_buf[i] = allow_list_ids[i][0..allow_list_id_lens[i]];
+    }
+
+    // Encode CTAP2 getAssertion command
+    var cmd_buf: [2048]u8 = undefined;
+    const cmd = ctap2.encodeGetAssertion(
+        &cmd_buf,
+        std.mem.span(rp_id),
+        client_data_hash[0..32],
+        ids_buf[0..count],
+    ) catch return CTAP2_ERR_CBOR;
+
+    // Send and receive
+    const result_len = ctaphidTransaction(&dev, cmd, result_buf[0..result_buf_len]) catch |err| {
+        return switch (err) {
+            error.NoDeviceFound => CTAP2_ERR_NO_DEVICE,
+            error.Timeout => CTAP2_ERR_TIMEOUT,
+            error.WriteFailed => CTAP2_ERR_WRITE_FAILED,
+            error.ReadFailed => CTAP2_ERR_READ_FAILED,
+            error.BufferTooSmall => CTAP2_ERR_BUFFER_TOO_SMALL,
+            else => CTAP2_ERR_PROTOCOL,
+        };
+    };
+
+    return @intCast(result_len);
+}
+
+/// Perform authenticatorGetInfo via direct USB HID.
+/// Returns bytes written to result_buf, or negative error code.
+export fn ctap2_get_info(
+    result_buf: [*]u8,
+    result_buf_len: usize,
+) callconv(.c) c_int {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var dev = hid.openFirst(allocator) catch return CTAP2_ERR_NO_DEVICE;
+    defer dev.close();
+
+    var cmd_buf: [8]u8 = undefined;
+    const cmd = ctap2.encodeGetInfo(&cmd_buf) catch return CTAP2_ERR_CBOR;
+
+    const result_len = ctaphidTransaction(&dev, cmd, result_buf[0..result_buf_len]) catch |err| {
+        return switch (err) {
+            error.NoDeviceFound => CTAP2_ERR_NO_DEVICE,
+            error.Timeout => CTAP2_ERR_TIMEOUT,
+            else => CTAP2_ERR_PROTOCOL,
+        };
+    };
+
+    return @intCast(result_len);
+}

--- a/src/hid.zig
+++ b/src/hid.zig
@@ -1,10 +1,19 @@
-/// Platform-selected USB HID transport.
+/// Platform-selected USB HID transport for FIDO2 devices.
+///
+/// Comptime selects between IOKit (macOS) and hidraw (Linux).
+/// Both implementations export the same interface:
+///   Device, enumerate(), openFirst()
 const std = @import("std");
 const builtin = @import("builtin");
 
-pub const impl = if (builtin.os.tag == .macos)
+pub const platform = if (builtin.os.tag == .macos)
     @import("hid_macos.zig")
 else if (builtin.os.tag == .linux)
     @import("hid_linux.zig")
 else
-    @compileError("Unsupported platform for USB HID FIDO2");
+    @compileError("Unsupported platform for USB HID FIDO2. Supported: macOS, Linux.");
+
+pub const Device = platform.Device;
+pub const Error = platform.Error;
+pub const enumerate = platform.enumerate;
+pub const openFirst = platform.openFirst;

--- a/src/hid_linux.zig
+++ b/src/hid_linux.zig
@@ -1,3 +1,142 @@
 /// Linux USB HID transport via hidraw.
-/// TODO: implement device enumeration and I/O
+///
+/// Enumerates FIDO2 devices by scanning /dev/hidraw* and checking
+/// sysfs for the FIDO usage page (0xF1D0). Provides read/write
+/// for 64-byte CTAPHID packets.
+
 const std = @import("std");
+const posix = std.posix;
+
+pub const Error = error{
+    NoDeviceFound,
+    OpenFailed,
+    WriteFailed,
+    ReadFailed,
+    Timeout,
+};
+
+/// FIDO HID usage page.
+const FIDO_USAGE_PAGE: u16 = 0xF1D0;
+
+/// A handle to an open FIDO2 HID device.
+pub const Device = struct {
+    fd: posix.fd_t,
+    path: [64]u8 = std.mem.zeroes([64]u8),
+
+    /// Write a 64-byte packet to the device.
+    pub fn write(self: *Device, packet: *const [64]u8) Error!void {
+        const written = posix.write(self.fd, packet) catch return Error.WriteFailed;
+        if (written != 64) return Error.WriteFailed;
+    }
+
+    /// Read a 64-byte packet from the device with timeout.
+    pub fn read(self: *Device, timeout_ms: u32) Error![64]u8 {
+        // Use poll for timeout
+        var fds = [1]posix.pollfd{.{
+            .fd = self.fd,
+            .events = posix.POLL.IN,
+            .revents = 0,
+        }};
+
+        const poll_result = posix.poll(&fds, @intCast(timeout_ms)) catch return Error.ReadFailed;
+        if (poll_result == 0) return Error.Timeout;
+        if (fds[0].revents & posix.POLL.IN == 0) return Error.ReadFailed;
+
+        var buf: [64]u8 = std.mem.zeroes([64]u8);
+        const bytes_read = posix.read(self.fd, &buf) catch return Error.ReadFailed;
+        if (bytes_read == 0) return Error.ReadFailed;
+
+        return buf;
+    }
+
+    /// Close the device.
+    pub fn close(self: *Device) void {
+        posix.close(self.fd);
+    }
+};
+
+/// Check if a hidraw device is a FIDO2 device by reading sysfs.
+fn isFidoDevice(path: []const u8) bool {
+    // Path: /dev/hidrawN → sysfs: /sys/class/hidraw/hidrawN/device/report_descriptor
+    // We need to parse the HID report descriptor to find usage page 0xF1D0
+    //
+    // Simpler approach: check the uevent file for HID_UNIQ or look at
+    // /sys/class/hidraw/hidrawN/device/uevent for vendor/product
+
+    // Extract hidrawN from path
+    const basename_start = std.mem.lastIndexOf(u8, path, "/") orelse return false;
+    const basename = path[basename_start + 1 ..];
+
+    var sysfs_path_buf: [256]u8 = undefined;
+    const sysfs_path = std.fmt.bufPrint(&sysfs_path_buf, "/sys/class/hidraw/{s}/device/report_descriptor", .{basename}) catch return false;
+
+    // Read the raw HID report descriptor
+    const file = std.fs.openFileAbsolute(sysfs_path, .{}) catch return false;
+    defer file.close();
+
+    var desc_buf: [4096]u8 = undefined;
+    const desc_len = file.readAll(&desc_buf) catch return false;
+    const desc = desc_buf[0..desc_len];
+
+    // Parse HID descriptor looking for usage page 0xF1D0
+    // Format: 0x06 <page_lo> <page_hi> for 2-byte usage page
+    var i: usize = 0;
+    while (i < desc.len) {
+        const item = desc[i];
+        const item_size = item & 0x03;
+        const item_type = (item >> 2) & 0x03;
+        const item_tag = (item >> 4) & 0x0F;
+
+        if (item_type == 1 and item_tag == 0 and item_size == 2) {
+            // Usage Page (2 bytes)
+            if (i + 2 < desc.len) {
+                const page = @as(u16, desc[i + 1]) | (@as(u16, desc[i + 2]) << 8);
+                if (page == FIDO_USAGE_PAGE) return true;
+            }
+        }
+
+        // Advance past this item
+        i += 1 + @as(usize, if (item_size == 3) 4 else item_size);
+    }
+
+    return false;
+}
+
+/// Enumerate connected FIDO2 USB HID devices.
+pub fn enumerate(allocator: std.mem.Allocator) ![]Device {
+    var devices = std.ArrayList(Device).init(allocator);
+    errdefer {
+        for (devices.items) |*dev| dev.close();
+        devices.deinit();
+    }
+
+    // Scan /dev/hidraw0 through /dev/hidraw15
+    var idx: u8 = 0;
+    while (idx < 16) : (idx += 1) {
+        var path_buf: [32]u8 = undefined;
+        const path = std.fmt.bufPrint(&path_buf, "/dev/hidraw{d}", .{idx}) catch continue;
+
+        if (!isFidoDevice(path)) continue;
+
+        const fd = posix.open(path, .{ .ACCMODE = .RDWR }, 0) catch continue;
+
+        var dev = Device{ .fd = fd };
+        @memcpy(dev.path[0..path.len], path);
+        try devices.append(dev);
+    }
+
+    return try devices.toOwnedSlice();
+}
+
+/// Find and open the first available FIDO2 device.
+pub fn openFirst(allocator: std.mem.Allocator) !Device {
+    const devices = try enumerate(allocator);
+    if (devices.len == 0) return Error.NoDeviceFound;
+
+    const first = devices[0];
+    for (devices[1..]) |*dev| {
+        dev.close();
+    }
+    allocator.free(devices);
+    return first;
+}

--- a/src/hid_macos.zig
+++ b/src/hid_macos.zig
@@ -1,3 +1,187 @@
 /// macOS USB HID transport via IOKit.
-/// TODO: implement device enumeration and I/O
+///
+/// Enumerates FIDO2 devices (USB HID usage page 0xF1D0), opens them,
+/// and provides read/write for 64-byte CTAPHID packets.
+
 const std = @import("std");
+const c = @cImport({
+    @cInclude("IOKit/hid/IOHIDManager.h");
+    @cInclude("CoreFoundation/CoreFoundation.h");
+});
+
+pub const Error = error{
+    NoDeviceFound,
+    OpenFailed,
+    WriteFailed,
+    ReadFailed,
+    Timeout,
+};
+
+/// FIDO HID usage page per spec.
+const FIDO_USAGE_PAGE: u32 = 0xF1D0;
+const FIDO_USAGE: u32 = 0x01;
+
+/// A handle to an open FIDO2 HID device.
+pub const Device = struct {
+    ref: c.IOHIDDeviceRef,
+    report_buf: [64]u8 = std.mem.zeroes([64]u8),
+    report_ready: bool = false,
+
+    /// Write a 64-byte packet to the device.
+    pub fn write(self: *Device, packet: *const [64]u8) Error!void {
+        // IOHIDDeviceSetReport: report type Output, report ID 0, skip first byte convention
+        const result = c.IOHIDDeviceSetReport(
+            self.ref,
+            c.kIOHIDReportTypeOutput,
+            0, // report ID
+            packet,
+            64,
+        );
+        if (result != c.kIOReturnSuccess) return Error.WriteFailed;
+    }
+
+    /// Read a 64-byte packet from the device with timeout.
+    pub fn read(self: *Device, timeout_ms: u32) Error![64]u8 {
+        self.report_ready = false;
+
+        // Create a unique run loop mode for this read
+        const mode = c.CFStringCreateWithCString(
+            null,
+            "com.zigctap2.hid.read",
+            c.kCFStringEncodingUTF8,
+        );
+        defer c.CFRelease(mode);
+
+        // Register input report callback
+        c.IOHIDDeviceRegisterInputReportCallback(
+            self.ref,
+            &self.report_buf,
+            64,
+            &reportCallback,
+            @ptrCast(self),
+        );
+
+        // Schedule with run loop
+        c.IOHIDDeviceScheduleWithRunLoop(
+            self.ref,
+            c.CFRunLoopGetCurrent(),
+            mode,
+        );
+
+        // Run until we get data or timeout
+        const timeout_sec: f64 = @as(f64, @floatFromInt(timeout_ms)) / 1000.0;
+        const run_result = c.CFRunLoopRunInMode(mode, timeout_sec, @intFromBool(true));
+
+        // Unschedule
+        c.IOHIDDeviceUnscheduleFromRunLoop(
+            self.ref,
+            c.CFRunLoopGetCurrent(),
+            mode,
+        );
+
+        if (run_result == c.kCFRunLoopRunTimedOut or !self.report_ready) {
+            return Error.Timeout;
+        }
+
+        return self.report_buf;
+    }
+
+    /// Close the device.
+    pub fn close(self: *Device) void {
+        _ = c.IOHIDDeviceClose(self.ref, c.kIOHIDOptionsTypeNone);
+    }
+};
+
+/// IOKit input report callback — fires when device sends data.
+fn reportCallback(
+    context: ?*anyopaque,
+    _: c.IOReturn,
+    _: ?*anyopaque,
+    _: c.IOHIDReportType,
+    _: u32,
+    _: [*c]u8,
+    _: c.CFIndex,
+) callconv(.c) void {
+    if (context) |ctx| {
+        const dev: *Device = @ptrCast(@alignCast(ctx));
+        dev.report_ready = true;
+        // Stop the run loop so read() returns
+        c.CFRunLoopStop(c.CFRunLoopGetCurrent());
+    }
+}
+
+/// Enumerate connected FIDO2 USB HID devices.
+/// Returns device refs that must be closed by the caller.
+pub fn enumerate(allocator: std.mem.Allocator) ![]Device {
+    const manager = c.IOHIDManagerCreate(c.kCFAllocatorDefault, c.kIOHIDManagerOptionNone);
+    if (manager == null) return Error.NoDeviceFound;
+    defer c.CFRelease(manager);
+
+    // Match FIDO HID devices (usage page 0xF1D0)
+    const usage_page_key = c.CFStringCreateWithCString(null, c.kIOHIDDeviceUsagePageKey, c.kCFStringEncodingUTF8);
+    defer c.CFRelease(usage_page_key);
+    const usage_key = c.CFStringCreateWithCString(null, c.kIOHIDDeviceUsageKey, c.kCFStringEncodingUTF8);
+    defer c.CFRelease(usage_key);
+    const usage_page_val = c.CFNumberCreate(null, c.kCFNumberSInt32Type, &@as(i32, @intCast(FIDO_USAGE_PAGE)));
+    defer c.CFRelease(usage_page_val);
+    const usage_val = c.CFNumberCreate(null, c.kCFNumberSInt32Type, &@as(i32, @intCast(FIDO_USAGE)));
+    defer c.CFRelease(usage_val);
+
+    var keys = [_]?*const anyopaque{ usage_page_key, usage_key };
+    var values = [_]?*const anyopaque{ usage_page_val, usage_val };
+    const matching = c.CFDictionaryCreate(
+        null,
+        @ptrCast(&keys),
+        @ptrCast(&values),
+        2,
+        &c.kCFTypeDictionaryKeyCallBacks,
+        &c.kCFTypeDictionaryValueCallBacks,
+    );
+    defer c.CFRelease(matching);
+
+    c.IOHIDManagerSetDeviceMatching(manager, matching);
+    _ = c.IOHIDManagerOpen(manager, c.kIOHIDManagerOptionNone);
+
+    const device_set = c.IOHIDManagerCopyDevices(manager);
+    if (device_set == null) return &[0]Device{};
+    defer c.CFRelease(device_set);
+
+    const count: usize = @intCast(c.CFSetGetCount(device_set));
+    if (count == 0) return &[0]Device{};
+
+    // Get device refs from CFSet
+    const raw_ptrs = try allocator.alloc(?*const anyopaque, count);
+    defer allocator.free(raw_ptrs);
+    c.CFSetGetValues(device_set, raw_ptrs.ptr);
+
+    var devices = try allocator.alloc(Device, count);
+    var valid: usize = 0;
+
+    for (raw_ptrs) |ptr| {
+        if (ptr) |p| {
+            const dev_ref: c.IOHIDDeviceRef = @constCast(@ptrCast(@alignCast(p)));
+
+            // Try to open the device
+            if (c.IOHIDDeviceOpen(dev_ref, c.kIOHIDOptionsTypeNone) == c.kIOReturnSuccess) {
+                devices[valid] = .{ .ref = dev_ref };
+                valid += 1;
+            }
+        }
+    }
+
+    return devices[0..valid];
+}
+
+/// Find and open the first available FIDO2 device.
+pub fn openFirst(allocator: std.mem.Allocator) !Device {
+    const devices = try enumerate(allocator);
+    if (devices.len == 0) return Error.NoDeviceFound;
+
+    // Return first, close the rest
+    const first = devices[0];
+    for (devices[1..]) |*dev| {
+        dev.close();
+    }
+    allocator.free(devices);
+    return first;
+}


### PR DESCRIPTION
Complete portable CTAP2 stack with platform HID transports and C FFI exports. Builds to libctap2.a.