### PR TITLE
Add property-based tests for CBOR and CTAPHID framing

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,4 +39,28 @@ pub fn build(b: *std.Build) void {
         });
         test_step.dependOn(&b.addRunArtifact(t).step);
     }
+
+    // Property-based tests
+    const pbt_step = b.step("test-pbt", "Run property-based tests");
+
+    inline for (.{
+        .{ .file = "tests/pbt_cbor.zig", .mod = "cbor" },
+        .{ .file = "tests/pbt_ctaphid.zig", .mod = "ctaphid" },
+    }) |entry| {
+        const t = b.addTest(.{
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(entry.file),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = entry.mod, .module = b.createModule(.{
+                        .root_source_file = b.path("src/" ++ entry.mod ++ ".zig"),
+                        .target = target,
+                        .optimize = optimize,
+                    }) },
+                },
+            }),
+        });
+        pbt_step.dependOn(&b.addRunArtifact(t).step);
+    }
 }

--- a/tests/pbt_cbor.zig
+++ b/tests/pbt_cbor.zig
@@ -1,0 +1,223 @@
+/// Property-based tests for CBOR encoder/decoder roundtrips.
+///
+/// Uses a fixed PRNG seed for reproducibility. Each property runs 1000 iterations
+/// with randomly generated inputs to verify encode/decode invariants.
+
+const std = @import("std");
+const cbor = @import("cbor");
+
+const ITERATIONS: usize = 1000;
+const SEED: u64 = 0xDEAD_BEEF_CAFE_F00D;
+
+// ─── Helpers ────────────────────────────────────────────────
+
+fn makeRng(seed: u64) std.Random.DefaultPrng {
+    return std.Random.DefaultPrng.init(seed);
+}
+
+/// Generate a random u64 with bias toward interesting boundary values.
+fn randomUint(rng: *std.Random.DefaultPrng) u64 {
+    const r = rng.random();
+    // 20% chance of a boundary value
+    if (r.intRangeAtMost(u8, 0, 4) == 0) {
+        const boundaries = [_]u64{
+            0, 1, 23, 24, 255, 256, 65535, 65536,
+            0xFFFFFFFF, 0x100000000, std.math.maxInt(u64),
+        };
+        return boundaries[r.intRangeAtMost(usize, 0, boundaries.len - 1)];
+    }
+    return r.int(u64);
+}
+
+/// Fill a buffer with random bytes and return a slice of random length up to `max_len`.
+fn randomBytes(rng: *std.Random.DefaultPrng, buf: []u8, max_len: usize) []u8 {
+    const r = rng.random();
+    const len = r.intRangeAtMost(usize, 0, max_len);
+    const slice = buf[0..len];
+    r.bytes(slice);
+    return slice;
+}
+
+/// Generate a random text string (printable ASCII for simplicity).
+fn randomText(rng: *std.Random.DefaultPrng, buf: []u8, max_len: usize) []u8 {
+    const r = rng.random();
+    const len = r.intRangeAtMost(usize, 0, max_len);
+    for (buf[0..len]) |*b| {
+        b.* = r.intRangeAtMost(u8, 0x20, 0x7E); // printable ASCII
+    }
+    return buf[0..len];
+}
+
+// ─── Property: unsigned integer roundtrip ───────────────────
+
+test "property: uint encode/decode roundtrip" {
+    var rng = makeRng(SEED);
+    var enc_buf: [16]u8 = undefined;
+
+    for (0..ITERATIONS) |_| {
+        const val = randomUint(&rng);
+
+        var enc = cbor.Encoder.init(&enc_buf);
+        try enc.encodeUint(val);
+
+        var dec = cbor.Decoder.init(enc.written());
+        const decoded = try dec.decodeUint();
+
+        try std.testing.expectEqual(val, decoded);
+        // All bytes consumed
+        try std.testing.expectEqual(@as(usize, 0), dec.remaining());
+    }
+}
+
+// ─── Property: byte string roundtrip ────────────────────────
+
+test "property: byte string encode/decode roundtrip" {
+    var rng = makeRng(SEED +% 1);
+    var data_buf: [1024]u8 = undefined;
+    var enc_buf: [1024 + 16]u8 = undefined;
+
+    for (0..ITERATIONS) |_| {
+        const data = randomBytes(&rng, &data_buf, 1024);
+
+        var enc = cbor.Encoder.init(&enc_buf);
+        try enc.encodeByteString(data);
+
+        var dec = cbor.Decoder.init(enc.written());
+        const decoded = try dec.decodeByteString();
+
+        try std.testing.expectEqualSlices(u8, data, decoded);
+        try std.testing.expectEqual(@as(usize, 0), dec.remaining());
+    }
+}
+
+// ─── Property: text string roundtrip ────────────────────────
+
+test "property: text string encode/decode roundtrip" {
+    var rng = makeRng(SEED +% 2);
+    var text_buf: [512]u8 = undefined;
+    var enc_buf: [512 + 16]u8 = undefined;
+
+    for (0..ITERATIONS) |_| {
+        const text = randomText(&rng, &text_buf, 512);
+
+        var enc = cbor.Encoder.init(&enc_buf);
+        try enc.encodeTextString(text);
+
+        var dec = cbor.Decoder.init(enc.written());
+        const decoded = try dec.decodeTextString();
+
+        try std.testing.expectEqualSlices(u8, text, decoded);
+        try std.testing.expectEqual(@as(usize, 0), dec.remaining());
+    }
+}
+
+// ─── Property: nested map encode then skip ──────────────────
+
+test "property: nested map encode/skip roundtrip" {
+    var rng = makeRng(SEED +% 3);
+    var enc_buf: [4096]u8 = undefined;
+    var val_buf: [256]u8 = undefined;
+
+    for (0..ITERATIONS) |_| {
+        const r = rng.random();
+        const entry_count = r.intRangeAtMost(usize, 1, 5);
+
+        var enc = cbor.Encoder.init(&enc_buf);
+        try enc.beginMap(entry_count);
+
+        // Write entries with integer keys and random value types
+        for (0..entry_count) |i| {
+            try enc.encodeUint(@intCast(i + 1));
+
+            const val_type = r.intRangeAtMost(u8, 0, 3);
+            switch (val_type) {
+                0 => try enc.encodeUint(randomUint(&rng)),
+                1 => {
+                    const data = randomBytes(&rng, &val_buf, 64);
+                    try enc.encodeByteString(data);
+                },
+                2 => {
+                    const text = randomText(&rng, &val_buf, 64);
+                    try enc.encodeTextString(text);
+                },
+                3 => try enc.encodeBool(r.boolean()),
+                else => unreachable,
+            }
+        }
+
+        // Append a sentinel after the map
+        try enc.encodeUint(0xCAFE);
+
+        // Decode: read map header, skip all entries, then read sentinel
+        var dec = cbor.Decoder.init(enc.written());
+        const map_len = try dec.decodeMapHeader();
+        try std.testing.expectEqual(entry_count, map_len);
+
+        for (0..entry_count) |_| {
+            try dec.skipValue(); // key
+            try dec.skipValue(); // value
+        }
+
+        // Sentinel must be reachable after skipping
+        const sentinel = try dec.decodeUint();
+        try std.testing.expectEqual(@as(u64, 0xCAFE), sentinel);
+        try std.testing.expectEqual(@as(usize, 0), dec.remaining());
+    }
+}
+
+// ─── Property: arbitrary value encode/decode identity ───────
+
+test "property: encode then decode produces original value" {
+    var rng = makeRng(SEED +% 4);
+    var enc_buf: [2048]u8 = undefined;
+    var val_buf: [256]u8 = undefined;
+
+    for (0..ITERATIONS) |_| {
+        const r = rng.random();
+        const val_type = r.intRangeAtMost(u8, 0, 4);
+
+        var enc = cbor.Encoder.init(&enc_buf);
+
+        switch (val_type) {
+            0 => {
+                // Unsigned integer
+                const val = randomUint(&rng);
+                try enc.encodeUint(val);
+                var dec = cbor.Decoder.init(enc.written());
+                try std.testing.expectEqual(val, try dec.decodeUint());
+            },
+            1 => {
+                // Byte string
+                const data = randomBytes(&rng, &val_buf, 256);
+                try enc.encodeByteString(data);
+                var dec = cbor.Decoder.init(enc.written());
+                try std.testing.expectEqualSlices(u8, data, try dec.decodeByteString());
+            },
+            2 => {
+                // Text string
+                const text = randomText(&rng, &val_buf, 256);
+                try enc.encodeTextString(text);
+                var dec = cbor.Decoder.init(enc.written());
+                try std.testing.expectEqualSlices(u8, text, try dec.decodeTextString());
+            },
+            3 => {
+                // Boolean
+                const val = r.boolean();
+                try enc.encodeBool(val);
+                // Decode manually: true=0xF5, false=0xF4
+                const encoded = enc.written();
+                try std.testing.expectEqual(@as(usize, 1), encoded.len);
+                const expected: u8 = if (val) 0xF5 else 0xF4;
+                try std.testing.expectEqual(expected, encoded[0]);
+            },
+            4 => {
+                // Null
+                try enc.encodeNull();
+                const encoded = enc.written();
+                try std.testing.expectEqual(@as(usize, 1), encoded.len);
+                try std.testing.expectEqual(@as(u8, 0xF6), encoded[0]);
+            },
+            else => unreachable,
+        }
+    }
+}

--- a/tests/pbt_ctaphid.zig
+++ b/tests/pbt_ctaphid.zig
@@ -1,0 +1,212 @@
+/// Property-based tests for CTAPHID message framing.
+///
+/// Verifies that arbitrary payloads survive fragmentation and reassembly,
+/// and that structural invariants (packet size, CID, sequence numbers,
+/// packet count) hold for all sizes.
+
+const std = @import("std");
+const ctaphid = @import("ctaphid");
+
+const ITERATIONS: usize = 1000;
+const SEED: u64 = 0xF1D0_2C7A_901D;
+
+fn makeRng(seed: u64) std.Random.DefaultPrng {
+    return std.Random.DefaultPrng.init(seed);
+}
+
+/// Expected number of packets for a given payload length.
+fn expectedPacketCount(len: usize) usize {
+    if (len <= ctaphid.INIT_DATA_SIZE) return 1;
+    // First packet carries INIT_DATA_SIZE bytes, each continuation carries CONT_DATA_SIZE
+    const remaining = len - ctaphid.INIT_DATA_SIZE;
+    return 1 + (remaining + ctaphid.CONT_DATA_SIZE - 1) / ctaphid.CONT_DATA_SIZE;
+}
+
+/// Extract CID from any packet (first 4 bytes, big-endian).
+fn extractCid(pkt: *const ctaphid.Packet) u32 {
+    return (@as(u32, pkt[0]) << 24) | (@as(u32, pkt[1]) << 16) |
+        (@as(u32, pkt[2]) << 8) | pkt[3];
+}
+
+// ─── Property: fragment and reassemble roundtrip ────────────
+// reassembleMessage uses a bare function pointer (no context), so we verify
+// the roundtrip property by manually extracting data from fragmented packets.
+
+test "property: fragment/reassemble roundtrip preserves payload" {
+    var rng = makeRng(SEED);
+    var payload_buf: [7609]u8 = undefined;
+    var packets: [130]ctaphid.Packet = undefined;
+    var reassembled: [7609]u8 = undefined;
+
+    for (0..ITERATIONS) |_| {
+        const r = rng.random();
+        const len = r.intRangeAtMost(usize, 0, 7609);
+        r.bytes(payload_buf[0..len]);
+        const payload = payload_buf[0..len];
+        const cid: u32 = r.int(u32) | 1;
+
+        const pkt_count = try ctaphid.fragmentMessage(cid, .cbor, payload, &packets);
+
+        // Extract data from init packet
+        var offset: usize = 0;
+        const init_copy = @min(len, ctaphid.INIT_DATA_SIZE);
+        @memcpy(reassembled[0..init_copy], packets[0][7..][0..init_copy]);
+        offset += init_copy;
+
+        // Extract data from continuation packets
+        for (1..pkt_count) |i| {
+            const remaining = len - offset;
+            const cont_copy = @min(remaining, ctaphid.CONT_DATA_SIZE);
+            @memcpy(reassembled[offset..][0..cont_copy], packets[i][5..][0..cont_copy]);
+            offset += cont_copy;
+        }
+
+        try std.testing.expectEqual(len, offset);
+        try std.testing.expectEqualSlices(u8, payload, reassembled[0..len]);
+    }
+}
+
+// ─── Property: packet count is correct ──────────────────────
+
+test "property: packet count matches formula" {
+    var rng = makeRng(SEED +% 1);
+    var payload_buf: [7609]u8 = undefined;
+    var packets: [130]ctaphid.Packet = undefined;
+
+    for (0..ITERATIONS) |_| {
+        const r = rng.random();
+        const len = r.intRangeAtMost(usize, 0, 7609);
+        r.bytes(payload_buf[0..len]);
+
+        const cid: u32 = r.int(u32) | 1;
+        const pkt_count = try ctaphid.fragmentMessage(cid, .cbor, payload_buf[0..len], &packets);
+        const expected = expectedPacketCount(len);
+
+        try std.testing.expectEqual(expected, pkt_count);
+    }
+}
+
+// ─── Property: all packets are exactly 64 bytes ─────────────
+
+test "property: all packets are exactly 64 bytes" {
+    var rng = makeRng(SEED +% 2);
+    var payload_buf: [7609]u8 = undefined;
+    var packets: [130]ctaphid.Packet = undefined;
+
+    for (0..ITERATIONS) |_| {
+        const r = rng.random();
+        const len = r.intRangeAtMost(usize, 0, 7609);
+        r.bytes(payload_buf[0..len]);
+
+        const cid: u32 = r.int(u32) | 1;
+        const pkt_count = try ctaphid.fragmentMessage(cid, .cbor, payload_buf[0..len], &packets);
+
+        for (0..pkt_count) |i| {
+            try std.testing.expectEqual(@as(usize, 64), packets[i].len);
+        }
+    }
+}
+
+// ─── Property: CID is consistent across all packets ─────────
+
+test "property: CID is consistent across all packets" {
+    var rng = makeRng(SEED +% 3);
+    var payload_buf: [7609]u8 = undefined;
+    var packets: [130]ctaphid.Packet = undefined;
+
+    for (0..ITERATIONS) |_| {
+        const r = rng.random();
+        const len = r.intRangeAtMost(usize, 0, 7609);
+        r.bytes(payload_buf[0..len]);
+
+        const cid: u32 = r.int(u32) | 1;
+        const pkt_count = try ctaphid.fragmentMessage(cid, .cbor, payload_buf[0..len], &packets);
+
+        for (0..pkt_count) |i| {
+            try std.testing.expectEqual(cid, extractCid(&packets[i]));
+        }
+    }
+}
+
+// ─── Property: continuation sequence numbers are sequential ──
+
+test "property: continuation sequence numbers are sequential" {
+    var rng = makeRng(SEED +% 4);
+    var payload_buf: [7609]u8 = undefined;
+    var packets: [130]ctaphid.Packet = undefined;
+
+    for (0..ITERATIONS) |_| {
+        const r = rng.random();
+        const len = r.intRangeAtMost(usize, 0, 7609);
+        r.bytes(payload_buf[0..len]);
+
+        const cid: u32 = r.int(u32) | 1;
+        const pkt_count = try ctaphid.fragmentMessage(cid, .cbor, payload_buf[0..len], &packets);
+
+        // Init packet has CMD byte with 0x80 flag
+        if (pkt_count > 0) {
+            try std.testing.expect(packets[0][4] & 0x80 != 0);
+        }
+
+        // Continuation packets: seq 0, 1, 2, ...
+        for (1..pkt_count) |i| {
+            const seq = packets[i][4];
+            try std.testing.expectEqual(@as(u8, @intCast(i - 1)), seq);
+        }
+    }
+}
+
+// ─── Boundary sizes ─────────────────────────────────────────
+
+test "boundary sizes: packet counts and data integrity" {
+    const boundary_sizes = [_]usize{ 0, 1, 56, 57, 58, 59, 116, 117, 7609 };
+    var payload_buf: [7609]u8 = undefined;
+    var packets: [130]ctaphid.Packet = undefined;
+    var reassembled: [7609]u8 = undefined;
+
+    // Fill with a recognizable pattern
+    for (&payload_buf, 0..) |*b, i| {
+        b.* = @intCast(i % 256);
+    }
+
+    const cid: u32 = 0xAABBCCDD;
+
+    for (boundary_sizes) |len| {
+        const payload = payload_buf[0..len];
+        const pkt_count = try ctaphid.fragmentMessage(cid, .cbor, payload, &packets);
+
+        // Verify packet count
+        try std.testing.expectEqual(expectedPacketCount(len), pkt_count);
+
+        // Verify all packets are 64 bytes
+        for (0..pkt_count) |i| {
+            try std.testing.expectEqual(@as(usize, 64), packets[i].len);
+        }
+
+        // Verify CID consistency
+        for (0..pkt_count) |i| {
+            try std.testing.expectEqual(cid, extractCid(&packets[i]));
+        }
+
+        // Verify sequential continuation sequence numbers
+        for (1..pkt_count) |i| {
+            try std.testing.expectEqual(@as(u8, @intCast(i - 1)), packets[i][4]);
+        }
+
+        // Verify data roundtrip
+        var offset: usize = 0;
+        const init_copy = @min(len, ctaphid.INIT_DATA_SIZE);
+        @memcpy(reassembled[0..init_copy], packets[0][7..][0..init_copy]);
+        offset += init_copy;
+
+        for (1..pkt_count) |i| {
+            const remaining = len - offset;
+            const cont_copy = @min(remaining, ctaphid.CONT_DATA_SIZE);
+            @memcpy(reassembled[offset..][0..cont_copy], packets[i][5..][0..cont_copy]);
+            offset += cont_copy;
+        }
+
+        try std.testing.expectEqual(len, offset);
+        try std.testing.expectEqualSlices(u8, payload, reassembled[0..len]);
+    }
+}


### PR DESCRIPTION
1000-iteration PBT for CBOR roundtrips and CTAPHID packet fragmentation/reassembly.