### PR TITLE
Add CI: unit and PBT tests on macOS + Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-15, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+          use-cache: false
+
+      - name: Run unit tests
+        run: zig build test
+
+      - name: Run property-based tests
+        run: zig build test-pbt


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow that runs on push to main and PRs
- Tests run on both macOS-15 and ubuntu-latest with Zig 0.15.2
- Executes `zig build test` (unit tests) and `zig build test-pbt` (property-based tests)

## Test plan
- [ ] CI passes on macOS runner
- [ ] CI passes on Linux runner