### PR TITLE
Add CTAP2 response parsing and parsed FFI

### DIFF
--- a/include/ctap2.h
+++ b/include/ctap2.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-// Status codes
+// Status codes (negative = library error, positive = CTAP2 device status)
 #define CTAP2_OK                    0
 #define CTAP2_ERR_NO_DEVICE        -1
 #define CTAP2_ERR_TIMEOUT          -2
@@ -29,6 +29,10 @@ extern "C" {
 
 // Get the number of connected FIDO2 devices.
 int ctap2_device_count(void);
+
+// ─── Raw response functions ─────────────────────────────────
+// These return the raw CTAP2 response (status byte + CBOR) in result_buf.
+// The caller is responsible for parsing the CBOR response.
 
 // Perform authenticatorMakeCredential.
 // client_data_hash must be 32 bytes (SHA-256 of clientDataJSON).
@@ -72,9 +76,94 @@ int ctap2_get_info(
     size_t result_buf_len
 );
 
-// Map a CTAP2 status byte to a human-readable error message.
+// ─── Parsed response functions ──────────────────────────────
+// These perform the CTAP2 command AND parse the CBOR response,
+// returning structured fields in caller-provided output buffers.
+//
+// Return values:
+//   CTAP2_OK (0)   = success, output fields populated
+//   > 0            = CTAP2 device status byte (e.g. 0x27 = user denied)
+//   < 0            = library error code (CTAP2_ERR_*)
+
+// Combined: send makeCredential + parse response.
+// Output buffers should be at least 1024 bytes for credential_id,
+// and 4096 bytes for attestation_object.
+int ctap2_make_credential_parsed(
+    const uint8_t *client_data_hash,     // 32 bytes
+    const char *rp_id,                    // null-terminated
+    const char *rp_name,                  // null-terminated
+    const uint8_t *user_id,
+    size_t user_id_len,
+    const char *user_name,               // null-terminated
+    const char *user_display_name,       // null-terminated
+    const int32_t *alg_ids,              // COSE algorithm IDs
+    size_t alg_count,
+    bool resident_key,
+    // Output fields:
+    uint8_t *out_credential_id,
+    size_t *out_credential_id_len,
+    uint8_t *out_attestation_object,
+    size_t *out_attestation_object_len
+);
+
+// Combined: send getAssertion + parse response.
+// Output buffers should be at least 1024 bytes each.
+// allow_list_ids/allow_list_id_lens can be NULL when allow_list_count is 0.
+int ctap2_get_assertion_parsed(
+    const uint8_t *client_data_hash,     // 32 bytes
+    const char *rp_id,                    // null-terminated
+    const uint8_t *const *allow_list_ids,    // nullable
+    const size_t *allow_list_id_lens,        // nullable
+    size_t allow_list_count,
+    // Output fields:
+    uint8_t *out_credential_id,
+    size_t *out_credential_id_len,
+    uint8_t *out_auth_data,
+    size_t *out_auth_data_len,
+    uint8_t *out_signature,
+    size_t *out_signature_len,
+    uint8_t *out_user_handle,
+    size_t *out_user_handle_len
+);
+
+// ─── Pure parsing functions ─────────────────────────────────
+// Parse raw CTAP2 response bytes without any HID I/O.
+// Useful when you already have the raw response from ctap2_make_credential
+// or ctap2_get_assertion and want to extract structured fields.
+
+// Parse a raw MakeCredential response (status byte + CBOR attestation object).
+int ctap2_parse_make_credential_response(
+    const uint8_t *response_data,
+    size_t response_len,
+    uint8_t *out_credential_id,
+    size_t *out_credential_id_len,
+    uint8_t *out_attestation_object,
+    size_t *out_attestation_object_len
+);
+
+// Parse a raw GetAssertion response (status byte + CBOR).
+// fallback_cred_id: credential ID to use when the response omits key 1
+// (CTAP2 spec: single-entry allowList). Pass NULL/0 if no fallback.
+int ctap2_parse_get_assertion_response(
+    const uint8_t *response_data,
+    size_t response_len,
+    const uint8_t *fallback_cred_id,     // nullable
+    size_t fallback_cred_id_len,
+    uint8_t *out_credential_id,
+    size_t *out_credential_id_len,
+    uint8_t *out_auth_data,
+    size_t *out_auth_data_len,
+    uint8_t *out_signature,
+    size_t *out_signature_len,
+    uint8_t *out_user_handle,
+    size_t *out_user_handle_len
+);
+
+// ─── Utility functions ──────────────────────────────────────
+
+// Map a CTAP2 status byte to a human-readable error message string.
 // Returns a pointer to a static null-terminated string.
-const char* ctap2_status_message(uint8_t status);
+const char *ctap2_status_message(uint8_t status);
 
 // Debug: get the last IOReturn error code from HID operations.
 int ctap2_debug_last_ioreturn(void);

--- a/src/ctap2.zig
+++ b/src/ctap2.zig
@@ -174,6 +174,207 @@ pub fn encodeGetInfo(buf: []u8) cbor.Error![]const u8 {
     return enc.written();
 }
 
+// ─── Response Parsing ────────────────────────────────────────
+
+/// Parsed result from authenticatorMakeCredential.
+pub const MakeCredentialResult = struct {
+    /// CTAP2 status byte (0x00 = success).
+    status: u8,
+    /// Credential ID extracted from authData attested credential data.
+    credential_id: []const u8,
+    /// Full attestation object (CBOR bytes, starting after status byte).
+    attestation_object: []const u8,
+    /// Raw authenticator data (authData field from the attestation object).
+    auth_data: []const u8,
+};
+
+/// Parsed result from authenticatorGetAssertion.
+pub const GetAssertionResult = struct {
+    /// CTAP2 status byte (0x00 = success).
+    status: u8,
+    /// Credential ID (from response key 1, or fallback if omitted).
+    credential_id: []const u8,
+    /// Raw authenticator data bytes.
+    auth_data: []const u8,
+    /// Signature bytes.
+    signature: []const u8,
+    /// User handle bytes (empty if not present).
+    user_handle: []const u8,
+};
+
+/// Parse a raw CTAP2 authenticatorMakeCredential response.
+///
+/// The response format is: status_byte(1) + CBOR_map
+/// The CBOR map has integer keys:
+///   1 = fmt (text string)
+///   2 = authData (byte string)
+///   3 = attStmt (map)
+///
+/// From authData we extract the credential ID:
+///   rpIdHash(32) + flags(1) + signCount(4) + [aaguid(16) + credIdLen(2) + credentialId(credIdLen) + ...]
+pub fn parseMakeCredentialResponse(response_data: []const u8) cbor.Error!MakeCredentialResult {
+    if (response_data.len < 1) return cbor.Error.Truncated;
+
+    const status = response_data[0];
+    if (status != 0x00) {
+        return MakeCredentialResult{
+            .status = status,
+            .credential_id = &.{},
+            .attestation_object = &.{},
+            .auth_data = &.{},
+        };
+    }
+
+    if (response_data.len < 2) return cbor.Error.Truncated;
+
+    // The attestation object is everything after the status byte
+    const attestation_object = response_data[1..];
+
+    // Parse the CBOR map
+    var dec = cbor.Decoder.init(attestation_object);
+    const map_len = try dec.decodeMapHeader();
+
+    var auth_data: []const u8 = &.{};
+
+    // Iterate the map looking for key 2 (authData)
+    for (0..map_len) |_| {
+        const key = try dec.decodeUint();
+        if (key == 2) {
+            // authData is a byte string
+            auth_data = try dec.decodeByteString();
+        } else {
+            // Skip value for other keys (1=fmt, 3=attStmt)
+            try dec.skipValue();
+        }
+    }
+
+    if (auth_data.len == 0) return cbor.Error.InvalidCbor;
+
+    // Extract credential ID from authData:
+    // rpIdHash(32) + flags(1) + signCount(4) = 37 bytes minimum
+    // If flags bit 6 (AT) is set, attested credential data follows:
+    //   aaguid(16) + credIdLen(2, big-endian) + credentialId(credIdLen)
+    if (auth_data.len < 37) return cbor.Error.Truncated;
+
+    const flags = auth_data[32];
+    const has_attested_data = (flags & 0x40) != 0; // bit 6 = AT flag
+
+    if (!has_attested_data) return cbor.Error.InvalidCbor;
+
+    // 37 + 16 (aaguid) + 2 (credIdLen) = 55 minimum
+    if (auth_data.len < 55) return cbor.Error.Truncated;
+
+    const cred_id_len = @as(usize, auth_data[53]) << 8 | @as(usize, auth_data[54]);
+    if (auth_data.len < 55 + cred_id_len) return cbor.Error.Truncated;
+
+    const credential_id = auth_data[55..][0..cred_id_len];
+
+    return MakeCredentialResult{
+        .status = status,
+        .credential_id = credential_id,
+        .attestation_object = attestation_object,
+        .auth_data = auth_data,
+    };
+}
+
+/// Parse a raw CTAP2 authenticatorGetAssertion response.
+///
+/// The response format is: status_byte(1) + CBOR_map
+/// The CBOR map has integer keys:
+///   1 = credential (map with "id" byte string) — optional per spec
+///   2 = authData (byte string)
+///   3 = signature (byte string)
+///   4 = user (map with "id" byte string) — optional
+///
+/// Per CTAP2 spec: key 1 (credential) is omitted when the allowList in the
+/// request had exactly one entry. In that case, use the fallback credential ID.
+pub fn parseGetAssertionResponse(
+    response_data: []const u8,
+    fallback_cred_id: ?[]const u8,
+) cbor.Error!GetAssertionResult {
+    if (response_data.len < 1) return cbor.Error.Truncated;
+
+    const status = response_data[0];
+    if (status != 0x00) {
+        return GetAssertionResult{
+            .status = status,
+            .credential_id = &.{},
+            .auth_data = &.{},
+            .signature = &.{},
+            .user_handle = &.{},
+        };
+    }
+
+    if (response_data.len < 2) return cbor.Error.Truncated;
+
+    var dec = cbor.Decoder.init(response_data[1..]);
+    const map_len = try dec.decodeMapHeader();
+
+    var credential_id: ?[]const u8 = null;
+    var auth_data: ?[]const u8 = null;
+    var signature: ?[]const u8 = null;
+    var user_handle: []const u8 = &.{};
+
+    for (0..map_len) |_| {
+        const key = try dec.decodeUint();
+        switch (key) {
+            1 => {
+                // credential: map containing "id" (byte string) and "type" (text)
+                const inner_map_len = try dec.decodeMapHeader();
+                for (0..inner_map_len) |_| {
+                    const inner_key = try dec.decodeTextString();
+                    if (std.mem.eql(u8, inner_key, "id")) {
+                        credential_id = try dec.decodeByteString();
+                    } else {
+                        try dec.skipValue();
+                    }
+                }
+            },
+            2 => {
+                auth_data = try dec.decodeByteString();
+            },
+            3 => {
+                signature = try dec.decodeByteString();
+            },
+            4 => {
+                // user: map containing "id" (byte string) and optionally "name", "displayName"
+                const inner_map_len = try dec.decodeMapHeader();
+                for (0..inner_map_len) |_| {
+                    const inner_key = try dec.decodeTextString();
+                    if (std.mem.eql(u8, inner_key, "id")) {
+                        user_handle = try dec.decodeByteString();
+                    } else {
+                        try dec.skipValue();
+                    }
+                }
+            },
+            else => {
+                try dec.skipValue();
+            },
+        }
+    }
+
+    // Use fallback credential ID if not present in response
+    if (credential_id == null) {
+        if (fallback_cred_id) |fb| {
+            credential_id = fb;
+        } else {
+            return cbor.Error.InvalidCbor;
+        }
+    }
+
+    // authData and signature are required
+    if (auth_data == null or signature == null) return cbor.Error.InvalidCbor;
+
+    return GetAssertionResult{
+        .status = status,
+        .credential_id = credential_id.?,
+        .auth_data = auth_data.?,
+        .signature = signature.?,
+        .user_handle = user_handle,
+    };
+}
+
 // ─── Tests ──────────────────────────────────────────────────
 
 test "encode makeCredential" {
@@ -236,4 +437,265 @@ test "statusMessage known codes" {
 
 test "statusMessage unknown code" {
     try std.testing.expectEqualStrings("Unknown authenticator error", statusMessage(0xFF));
+}
+
+// ─── Response Parsing Tests ─────────────────────────────────
+
+test "parseMakeCredentialResponse: non-zero status returns error status" {
+    // Status byte 0x27 = operation denied
+    const response = [_]u8{0x27};
+    const result = try parseMakeCredentialResponse(&response);
+    try std.testing.expectEqual(@as(u8, 0x27), result.status);
+    try std.testing.expectEqual(@as(usize, 0), result.credential_id.len);
+}
+
+test "parseMakeCredentialResponse: valid attestation object" {
+    // Build a synthetic MakeCredential response:
+    // status(0x00) + CBOR map {1: "packed", 2: authData, 3: {}}
+    var buf: [512]u8 = undefined;
+    var pos: usize = 0;
+
+    // Status byte
+    buf[pos] = 0x00;
+    pos += 1;
+
+    // Build the CBOR attestation object in a separate encoder
+    var cbor_buf: [512]u8 = undefined;
+    var enc = cbor.Encoder.init(&cbor_buf);
+
+    // Map with 3 entries
+    try enc.beginMap(3);
+
+    // Key 1: fmt = "packed"
+    try enc.encodeUint(1);
+    try enc.encodeTextString("packed");
+
+    // Key 2: authData (byte string)
+    // authData: rpIdHash(32) + flags(1) + signCount(4) + aaguid(16) + credIdLen(2) + credentialId(64)
+    var auth_data: [119]u8 = undefined;
+    // rpIdHash: 32 bytes of 0xAA
+    @memset(auth_data[0..32], 0xAA);
+    // flags: 0x41 = UP (bit 0) + AT (bit 6) = attested credential data present
+    auth_data[32] = 0x41;
+    // signCount: 4 bytes, value 1
+    auth_data[33] = 0;
+    auth_data[34] = 0;
+    auth_data[35] = 0;
+    auth_data[36] = 1;
+    // aaguid: 16 bytes of 0xBB
+    @memset(auth_data[37..53], 0xBB);
+    // credIdLen: 64 (big-endian)
+    auth_data[53] = 0;
+    auth_data[54] = 64;
+    // credentialId: 64 bytes of 0xCC
+    @memset(auth_data[55..119], 0xCC);
+
+    try enc.encodeUint(2);
+    try enc.encodeByteString(&auth_data);
+
+    // Key 3: attStmt = {} (empty map)
+    try enc.encodeUint(3);
+    try enc.beginMap(0);
+
+    const cbor_written = enc.written();
+    @memcpy(buf[pos..][0..cbor_written.len], cbor_written);
+    pos += cbor_written.len;
+
+    const response = buf[0..pos];
+    const result = try parseMakeCredentialResponse(response);
+
+    try std.testing.expectEqual(@as(u8, 0x00), result.status);
+    try std.testing.expectEqual(@as(usize, 64), result.credential_id.len);
+    // Verify credential ID bytes are all 0xCC
+    for (result.credential_id) |b| {
+        try std.testing.expectEqual(@as(u8, 0xCC), b);
+    }
+    // Attestation object should be everything after the status byte
+    try std.testing.expectEqual(pos - 1, result.attestation_object.len);
+    // Auth data should be 119 bytes
+    try std.testing.expectEqual(@as(usize, 119), result.auth_data.len);
+}
+
+test "parseGetAssertionResponse: non-zero status returns error status" {
+    const response = [_]u8{0x2E}; // noCredentials
+    const result = try parseGetAssertionResponse(&response, null);
+    try std.testing.expectEqual(@as(u8, 0x2E), result.status);
+    try std.testing.expectEqual(@as(usize, 0), result.credential_id.len);
+}
+
+test "parseGetAssertionResponse: valid assertion with credential" {
+    // Build a synthetic GetAssertion response:
+    // status(0x00) + CBOR map {1: {id: <cred>, type: "public-key"}, 2: authData, 3: signature}
+    var buf: [512]u8 = undefined;
+    var pos: usize = 0;
+
+    // Status byte
+    buf[pos] = 0x00;
+    pos += 1;
+
+    var cbor_buf: [512]u8 = undefined;
+    var enc = cbor.Encoder.init(&cbor_buf);
+
+    // Map with 3 entries (no user handle)
+    try enc.beginMap(3);
+
+    // Key 1: credential descriptor map
+    try enc.encodeUint(1);
+    try enc.beginMap(2);
+    try enc.encodeTextString("id");
+    const cred_id = [_]u8{0xDE} ** 32;
+    try enc.encodeByteString(&cred_id);
+    try enc.encodeTextString("type");
+    try enc.encodeTextString("public-key");
+
+    // Key 2: authData (37 bytes: rpIdHash + flags + signCount)
+    try enc.encodeUint(2);
+    var auth_data: [37]u8 = undefined;
+    @memset(auth_data[0..32], 0xAA); // rpIdHash
+    auth_data[32] = 0x01; // flags: UP
+    auth_data[33] = 0;
+    auth_data[34] = 0;
+    auth_data[35] = 0;
+    auth_data[36] = 5; // signCount = 5
+    try enc.encodeByteString(&auth_data);
+
+    // Key 3: signature
+    try enc.encodeUint(3);
+    const sig = [_]u8{0xFF} ** 72;
+    try enc.encodeByteString(&sig);
+
+    const cbor_written = enc.written();
+    @memcpy(buf[pos..][0..cbor_written.len], cbor_written);
+    pos += cbor_written.len;
+
+    const response = buf[0..pos];
+    const result = try parseGetAssertionResponse(response, null);
+
+    try std.testing.expectEqual(@as(u8, 0x00), result.status);
+    try std.testing.expectEqual(@as(usize, 32), result.credential_id.len);
+    try std.testing.expectEqual(@as(u8, 0xDE), result.credential_id[0]);
+    try std.testing.expectEqual(@as(usize, 37), result.auth_data.len);
+    try std.testing.expectEqual(@as(usize, 72), result.signature.len);
+    try std.testing.expectEqual(@as(usize, 0), result.user_handle.len);
+}
+
+test "parseGetAssertionResponse: credential omitted, fallback used" {
+    // Per CTAP2 spec, key 1 is omitted when allowList had one entry.
+    // Build response with only keys 2 and 3.
+    var buf: [512]u8 = undefined;
+    var pos: usize = 0;
+
+    buf[pos] = 0x00;
+    pos += 1;
+
+    var cbor_buf: [512]u8 = undefined;
+    var enc = cbor.Encoder.init(&cbor_buf);
+
+    // Map with 2 entries (no credential, no user)
+    try enc.beginMap(2);
+
+    // Key 2: authData
+    try enc.encodeUint(2);
+    var auth_data: [37]u8 = undefined;
+    @memset(&auth_data, 0x11);
+    try enc.encodeByteString(&auth_data);
+
+    // Key 3: signature
+    try enc.encodeUint(3);
+    const sig = [_]u8{0x22} ** 64;
+    try enc.encodeByteString(&sig);
+
+    const cbor_written = enc.written();
+    @memcpy(buf[pos..][0..cbor_written.len], cbor_written);
+    pos += cbor_written.len;
+
+    const fallback = [_]u8{0xAB} ** 16;
+    const response = buf[0..pos];
+    const result = try parseGetAssertionResponse(response, &fallback);
+
+    try std.testing.expectEqual(@as(u8, 0x00), result.status);
+    // Should use the fallback credential ID
+    try std.testing.expectEqual(@as(usize, 16), result.credential_id.len);
+    try std.testing.expectEqual(@as(u8, 0xAB), result.credential_id[0]);
+}
+
+test "parseGetAssertionResponse: credential omitted, no fallback fails" {
+    var buf: [512]u8 = undefined;
+    var pos: usize = 0;
+
+    buf[pos] = 0x00;
+    pos += 1;
+
+    var cbor_buf: [512]u8 = undefined;
+    var enc = cbor.Encoder.init(&cbor_buf);
+
+    try enc.beginMap(2);
+    try enc.encodeUint(2);
+    try enc.encodeByteString(&([_]u8{0} ** 37));
+    try enc.encodeUint(3);
+    try enc.encodeByteString(&([_]u8{0} ** 64));
+
+    const cbor_written = enc.written();
+    @memcpy(buf[pos..][0..cbor_written.len], cbor_written);
+    pos += cbor_written.len;
+
+    const response = buf[0..pos];
+    try std.testing.expectError(cbor.Error.InvalidCbor, parseGetAssertionResponse(response, null));
+}
+
+test "parseGetAssertionResponse: with user handle" {
+    var buf: [512]u8 = undefined;
+    var pos: usize = 0;
+
+    buf[pos] = 0x00;
+    pos += 1;
+
+    var cbor_buf: [512]u8 = undefined;
+    var enc = cbor.Encoder.init(&cbor_buf);
+
+    // Map with 4 entries including user
+    try enc.beginMap(4);
+
+    // Key 1: credential
+    try enc.encodeUint(1);
+    try enc.beginMap(2);
+    try enc.encodeTextString("id");
+    try enc.encodeByteString(&([_]u8{0xAA} ** 32));
+    try enc.encodeTextString("type");
+    try enc.encodeTextString("public-key");
+
+    // Key 2: authData
+    try enc.encodeUint(2);
+    try enc.encodeByteString(&([_]u8{0xBB} ** 37));
+
+    // Key 3: signature
+    try enc.encodeUint(3);
+    try enc.encodeByteString(&([_]u8{0xCC} ** 64));
+
+    // Key 4: user with "id" field
+    try enc.encodeUint(4);
+    try enc.beginMap(1);
+    try enc.encodeTextString("id");
+    const user_id = [_]u8{ 0x01, 0x02, 0x03, 0x04 };
+    try enc.encodeByteString(&user_id);
+
+    const cbor_written = enc.written();
+    @memcpy(buf[pos..][0..cbor_written.len], cbor_written);
+    pos += cbor_written.len;
+
+    const response = buf[0..pos];
+    const result = try parseGetAssertionResponse(response, null);
+
+    try std.testing.expectEqual(@as(u8, 0x00), result.status);
+    try std.testing.expectEqual(@as(usize, 4), result.user_handle.len);
+    try std.testing.expectEqual(@as(u8, 0x01), result.user_handle[0]);
+    try std.testing.expectEqual(@as(u8, 0x04), result.user_handle[3]);
+}
+
+test "parseMakeCredentialResponse: empty input returns Truncated" {
+    try std.testing.expectError(cbor.Error.Truncated, parseMakeCredentialResponse(&.{}));
+}
+
+test "parseGetAssertionResponse: empty input returns Truncated" {
+    try std.testing.expectError(cbor.Error.Truncated, parseGetAssertionResponse(&.{}, null));
 }

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -246,6 +246,266 @@ export fn ctap2_get_info(
     return @intCast(result_len);
 }
 
+// ─── Parsed Response Functions ───────────────────────────────
+
+/// Perform authenticatorMakeCredential and parse the response.
+/// Sends the CTAP2 command, receives the raw response, then parses the CBOR
+/// attestation object to extract the credential ID and attestation object.
+///
+/// Returns CTAP2_OK on success, or negative error code.
+/// On CTAP2 device error (non-zero status byte), returns the positive status byte.
+export fn ctap2_make_credential_parsed(
+    client_data_hash: [*]const u8, // 32 bytes
+    rp_id: [*:0]const u8,
+    rp_name: [*:0]const u8,
+    user_id: [*]const u8,
+    user_id_len: usize,
+    user_name: [*:0]const u8,
+    user_display_name: [*:0]const u8,
+    alg_ids: [*]const i32,
+    alg_count: usize,
+    resident_key: bool,
+    // Output fields:
+    out_credential_id: [*]u8,
+    out_credential_id_len: *usize,
+    out_attestation_object: [*]u8,
+    out_attestation_object_len: *usize,
+) callconv(.c) c_int {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Open first FIDO2 device
+    var dev = hid.openFirst(allocator) catch return CTAP2_ERR_NO_DEVICE;
+    defer dev.close();
+
+    // Encode CTAP2 makeCredential command
+    var cmd_buf: [2048]u8 = undefined;
+    const cmd = ctap2.encodeMakeCredential(
+        &cmd_buf,
+        client_data_hash[0..32],
+        std.mem.span(rp_id),
+        std.mem.span(rp_name),
+        user_id[0..user_id_len],
+        std.mem.span(user_name),
+        std.mem.span(user_display_name),
+        @ptrCast(alg_ids[0..alg_count]),
+        resident_key,
+    ) catch return CTAP2_ERR_CBOR;
+
+    // Send and receive raw response
+    var raw_buf: [4096]u8 = undefined;
+    const raw_len = ctaphidTransaction(&dev, cmd, &raw_buf) catch |err| {
+        return switch (err) {
+            error.NoDeviceFound => CTAP2_ERR_NO_DEVICE,
+            error.Timeout => CTAP2_ERR_TIMEOUT,
+            error.WriteFailed => CTAP2_ERR_WRITE_FAILED,
+            error.ReadFailed => CTAP2_ERR_READ_FAILED,
+            error.BufferTooSmall => CTAP2_ERR_BUFFER_TOO_SMALL,
+            else => CTAP2_ERR_PROTOCOL,
+        };
+    };
+
+    // Parse the response
+    const result = ctap2.parseMakeCredentialResponse(raw_buf[0..raw_len]) catch return CTAP2_ERR_CBOR;
+
+    if (result.status != 0x00) {
+        return @intCast(result.status);
+    }
+
+    // Copy credential ID to output buffer
+    const cred_id = result.credential_id;
+    @memcpy(out_credential_id[0..cred_id.len], cred_id);
+    out_credential_id_len.* = cred_id.len;
+
+    // Copy attestation object to output buffer
+    const att_obj = result.attestation_object;
+    @memcpy(out_attestation_object[0..att_obj.len], att_obj);
+    out_attestation_object_len.* = att_obj.len;
+
+    return CTAP2_OK;
+}
+
+/// Perform authenticatorGetAssertion and parse the response.
+/// Sends the CTAP2 command, receives the raw response, then parses the CBOR
+/// to extract credential ID, authenticator data, signature, and user handle.
+///
+/// Returns CTAP2_OK on success, or negative error code.
+/// On CTAP2 device error (non-zero status byte), returns the positive status byte.
+export fn ctap2_get_assertion_parsed(
+    client_data_hash: [*]const u8, // 32 bytes
+    rp_id: [*:0]const u8,
+    allow_list_ids: ?[*]const [*]const u8,
+    allow_list_id_lens: ?[*]const usize,
+    allow_list_count: usize,
+    // Output fields:
+    out_credential_id: [*]u8,
+    out_credential_id_len: *usize,
+    out_auth_data: [*]u8,
+    out_auth_data_len: *usize,
+    out_signature: [*]u8,
+    out_signature_len: *usize,
+    out_user_handle: [*]u8,
+    out_user_handle_len: *usize,
+) callconv(.c) c_int {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Open first FIDO2 device
+    var dev = hid.openFirst(allocator) catch return CTAP2_ERR_NO_DEVICE;
+    defer dev.close();
+
+    // Build allow list slices
+    var ids_buf: [64][]const u8 = undefined;
+    const count = @min(allow_list_count, 64);
+    if (allow_list_ids != null and allow_list_id_lens != null) {
+        const ids = allow_list_ids.?;
+        const lens = allow_list_id_lens.?;
+        for (0..count) |i| {
+            ids_buf[i] = ids[i][0..lens[i]];
+        }
+    }
+
+    // Encode CTAP2 getAssertion command
+    var cmd_buf: [2048]u8 = undefined;
+    const cmd = ctap2.encodeGetAssertion(
+        &cmd_buf,
+        std.mem.span(rp_id),
+        client_data_hash[0..32],
+        if (allow_list_ids != null) ids_buf[0..count] else ids_buf[0..0],
+    ) catch return CTAP2_ERR_CBOR;
+
+    // Send and receive raw response
+    var raw_buf: [4096]u8 = undefined;
+    const raw_len = ctaphidTransaction(&dev, cmd, &raw_buf) catch |err| {
+        return switch (err) {
+            error.NoDeviceFound => CTAP2_ERR_NO_DEVICE,
+            error.Timeout => CTAP2_ERR_TIMEOUT,
+            error.WriteFailed => CTAP2_ERR_WRITE_FAILED,
+            error.ReadFailed => CTAP2_ERR_READ_FAILED,
+            error.BufferTooSmall => CTAP2_ERR_BUFFER_TOO_SMALL,
+            else => CTAP2_ERR_PROTOCOL,
+        };
+    };
+
+    // Build fallback credential ID (first entry in allow list, if exactly one)
+    const fallback_cred_id: ?[]const u8 = if (count == 1 and allow_list_ids != null and allow_list_id_lens != null)
+        allow_list_ids.?[0][0..allow_list_id_lens.?[0]]
+    else
+        null;
+
+    // Parse the response
+    const result = ctap2.parseGetAssertionResponse(raw_buf[0..raw_len], fallback_cred_id) catch return CTAP2_ERR_CBOR;
+
+    if (result.status != 0x00) {
+        return @intCast(result.status);
+    }
+
+    // Copy outputs
+    const cred_id = result.credential_id;
+    @memcpy(out_credential_id[0..cred_id.len], cred_id);
+    out_credential_id_len.* = cred_id.len;
+
+    const auth_data = result.auth_data;
+    @memcpy(out_auth_data[0..auth_data.len], auth_data);
+    out_auth_data_len.* = auth_data.len;
+
+    const sig = result.signature;
+    @memcpy(out_signature[0..sig.len], sig);
+    out_signature_len.* = sig.len;
+
+    const user_handle = result.user_handle;
+    @memcpy(out_user_handle[0..user_handle.len], user_handle);
+    out_user_handle_len.* = user_handle.len;
+
+    return CTAP2_OK;
+}
+
+/// Parse a raw CTAP2 MakeCredential response buffer (status byte + CBOR).
+/// This is a pure parsing function — no HID I/O.
+/// Useful when the caller already has the raw response bytes.
+///
+/// Returns CTAP2_OK on success, positive status byte on device error,
+/// or negative error code on parse failure.
+export fn ctap2_parse_make_credential_response(
+    response_data: [*]const u8,
+    response_len: usize,
+    out_credential_id: [*]u8,
+    out_credential_id_len: *usize,
+    out_attestation_object: [*]u8,
+    out_attestation_object_len: *usize,
+) callconv(.c) c_int {
+    const result = ctap2.parseMakeCredentialResponse(response_data[0..response_len]) catch return CTAP2_ERR_CBOR;
+
+    if (result.status != 0x00) {
+        return @intCast(result.status);
+    }
+
+    const cred_id = result.credential_id;
+    @memcpy(out_credential_id[0..cred_id.len], cred_id);
+    out_credential_id_len.* = cred_id.len;
+
+    const att_obj = result.attestation_object;
+    @memcpy(out_attestation_object[0..att_obj.len], att_obj);
+    out_attestation_object_len.* = att_obj.len;
+
+    return CTAP2_OK;
+}
+
+/// Parse a raw CTAP2 GetAssertion response buffer (status byte + CBOR).
+/// This is a pure parsing function — no HID I/O.
+///
+/// fallback_cred_id/fallback_cred_id_len: credential ID to use when the
+/// response omits key 1 (CTAP2 spec: single-entry allowList). Pass NULL/0
+/// if no fallback is available.
+///
+/// Returns CTAP2_OK on success, positive status byte on device error,
+/// or negative error code on parse failure.
+export fn ctap2_parse_get_assertion_response(
+    response_data: [*]const u8,
+    response_len: usize,
+    fallback_cred_id: ?[*]const u8,
+    fallback_cred_id_len: usize,
+    out_credential_id: [*]u8,
+    out_credential_id_len: *usize,
+    out_auth_data: [*]u8,
+    out_auth_data_len: *usize,
+    out_signature: [*]u8,
+    out_signature_len: *usize,
+    out_user_handle: [*]u8,
+    out_user_handle_len: *usize,
+) callconv(.c) c_int {
+    const fb: ?[]const u8 = if (fallback_cred_id) |ptr|
+        ptr[0..fallback_cred_id_len]
+    else
+        null;
+
+    const result = ctap2.parseGetAssertionResponse(response_data[0..response_len], fb) catch return CTAP2_ERR_CBOR;
+
+    if (result.status != 0x00) {
+        return @intCast(result.status);
+    }
+
+    const cred_id = result.credential_id;
+    @memcpy(out_credential_id[0..cred_id.len], cred_id);
+    out_credential_id_len.* = cred_id.len;
+
+    const auth_data = result.auth_data;
+    @memcpy(out_auth_data[0..auth_data.len], auth_data);
+    out_auth_data_len.* = auth_data.len;
+
+    const sig = result.signature;
+    @memcpy(out_signature[0..sig.len], sig);
+    out_signature_len.* = sig.len;
+
+    const user_handle = result.user_handle;
+    @memcpy(out_user_handle[0..user_handle.len], user_handle);
+    out_user_handle_len.* = user_handle.len;
+
+    return CTAP2_OK;
+}
+
 /// Map a CTAP2 status byte to a human-readable error message.
 /// Returns a pointer to a static null-terminated string.
 export fn ctap2_status_message(status: u8) callconv(.c) [*:0]const u8 {


### PR DESCRIPTION
## Summary

- Add `parseMakeCredentialResponse` and `parseGetAssertionResponse` to `src/ctap2.zig` -- moves 300+ LOC of manual CBOR parsing from Swift (WebAuthnCoordinator) into the Zig library
- Add 4 new C FFI functions: `ctap2_make_credential_parsed`, `ctap2_get_assertion_parsed` (combined send+parse), and `ctap2_parse_make_credential_response`, `ctap2_parse_get_assertion_response` (pure parsing, no HID I/O)
- Update `include/ctap2.h` with all new function declarations
- Add 9 unit tests covering success paths, error status, CTAP2 spec fallback credential ID, user handle extraction, and edge cases

## Details

The response parsers handle the full CTAP2 response format:
- **MakeCredential**: status byte + CBOR map {1=fmt, 2=authData, 3=attStmt}, extracting credential ID from authData (rpIdHash(32) + flags(1) + signCount(4) + aaguid(16) + credIdLen(2) + credentialId)
- **GetAssertion**: status byte + CBOR map {1=credential, 2=authData, 3=signature, 4=user}, with fallback for omitted credential (CTAP2 spec: single-entry allowList)

Return value convention for parsed functions: `0` = success, `> 0` = CTAP2 device status byte, `< 0` = library error code.

## Test plan

- [x] `zig build` compiles successfully
- [x] `zig build test` passes all unit tests (9 new response parsing tests + existing tests)
- [ ] Verify Swift integration by switching WebAuthnCoordinator to use the new parsed FFI functions