### PR TITLE
fix: add DevicesNotAccessible to macOS error set

### DIFF
--- a/src/hid_macos.zig
+++ b/src/hid_macos.zig
@@ -14,6 +14,7 @@ const c = @cImport({
 
 pub const Error = error{
     NoDeviceFound,
+    DevicesNotAccessible,
     OpenFailed,
     WriteFailed,
     ReadFailed,


### PR DESCRIPTION
The hidraw hardening PR added DevicesNotAccessible to hid_linux.zig but not hid_macos.zig. Zig's error set type checking fails on macOS because ffi.zig matches on this error.