### PR TITLE
Add autodoc CI job and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,27 @@ jobs:
       - name: Run property-based tests
         run: zig build test-pbt
 
+  autodoc:
+    name: Autodoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+          use-cache: false
+
+      - name: Generate autodoc
+        run: zig build docs
+
+      - name: Upload autodoc artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: autodoc
+          path: zig-out/docs/
+
   secrets-scan:
     name: Secrets scan
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-15, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+          use-cache: false
+
+      - name: Run unit tests
+        run: zig build test
+
+      - name: Run property-based tests
+        run: zig build test-pbt
+
+  build:
+    name: Build ReleaseFast
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+          use-cache: false
+
+      - name: Build ReleaseFast
+        run: zig build -Doptimize=ReleaseFast
+
+  autodoc:
+    name: Autodoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+          use-cache: false
+
+      - name: Generate autodoc
+        run: zig build docs
+
+      - name: Upload autodoc artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: autodoc
+          path: zig-out/docs/
+
+  release:
+    name: Create GitHub Release
+    needs: [test, build, autodoc]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Create source tarball
+        run: |
+          git archive --format=tar.gz --prefix="zig-ctap2-${{ steps.version.outputs.VERSION }}/" \
+            -o "zig-ctap2-${{ steps.version.outputs.VERSION }}.tar.gz" HEAD
+
+      - name: Download autodoc artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: autodoc
+          path: autodoc/
+
+      - name: Create autodoc tarball
+        run: tar czf "zig-ctap2-${{ steps.version.outputs.VERSION }}-autodoc.tar.gz" -C autodoc .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            zig-ctap2-${{ steps.version.outputs.VERSION }}.tar.gz
+            zig-ctap2-${{ steps.version.outputs.VERSION }}-autodoc.tar.gz


### PR DESCRIPTION
## Summary
- Add `autodoc` job to CI that generates Zig autodoc and uploads as artifact
- Add `release.yml` workflow triggered on `v*` tags: runs tests + PBT, builds ReleaseFast, generates autodoc, creates source tarball and GitHub release with auto-generated notes
- Next release will be v0.4.0 (existing tags: v0.1.0 through v0.3.1)

## Test plan
- [ ] Push a branch to verify the autodoc CI job runs and uploads artifact
- [ ] Verify release workflow syntax with `act` or by tagging a test release